### PR TITLE
Exclude scenarios using the NOT operator '~' for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,24 @@ Most notable features are:
 - Features (Gherkin `feature` keyword): Will be transformed into a [TestCafé fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures).
 - Scenarios (Gherkin `scenario` keyword): Will be transformed into a [TestCafé test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests).
 - Scenario outlines (Gherkin `scenario outline` and `examples` keywords): Will transform every example into on [TestCafé test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests).
-- Tags/ Hooks: See [Hooks](#hooks).
+- Tags/ Hooks: See [Tags](#tags) and [Hooks](#hooks).
+
+### Tags
+
+Scenarios can be tagged using [Gherkin's @-notation](https://docs.cucumber.io/cucumber/api/#tags).
+The runner can then be configured to filter scenarios to be run based on these tags.
+The tags will be evaluated such that scenarios that have any of the including tags (begins with @) but none of the excluding tags (begins with ~@) will be run.
+
+Examples:
+
+```
+    runner.tags(['@TAG']) // Will run all scenarios marked with @TAG
+
+    runner.tags(['~@TAG']) // Will run all scenarios that are not marked with @TAG
+
+    runner.tags(['@TAG', '~@OTHER_TAG']) // Will run all scenarios that are marked with @TAG but not with @OTHER_TAG
+
+```
 
 ### Hooks
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "gherkin-testcafe",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Lukas Kullmann <lukas.kullmann@kiwigrid.com>",
   "contributors": [
     "Wilhelm Behncke <behncke@sitegeist.de>",
-    "Jarmo Koivisto"
+    "Jarmo Koivisto",
+    "Jakob Ström"
   ],
   "repository": {
     "type": "git",

--- a/src/TestcafeGherkinBootstrapper.js
+++ b/src/TestcafeGherkinBootstrapper.js
@@ -140,20 +140,25 @@ module.exports = class TestcafeGherkinBootstrapper extends TestcafeBootstrapper 
   }
 
   _shouldRunScenario(scenario) {
-    if (!this.tags.length) {
-      return true;
-    }
+    return (
+      this._scenarioHasAnyOfTheTags(scenario, this._getIncludingTags(this.tags)) &&
+      this._scenarioLacksTags(scenario, this._getExcludingTags(this.tags))
+    );
+  }
 
-    return this._scenarioHasAnyOfTheTags(scenario, this.tags);
+  _getIncludingTags(tags) {
+    return tags.filter(tag => !tag.startsWith('~'));
+  }
+
+  _getExcludingTags(tags) {
+    return tags.filter(tag => tag.startsWith('~')).map(tag => tag.slice(1));
   }
 
   _scenarioHasAnyOfTheTags(scenario, tags) {
-    for (let i = 0; i < scenario.tags.length; i++) {
-      if (tags.indexOf(scenario.tags[i].name) > -1) {
-        return true;
-      }
-    }
+    return !tags.length || tags.some(tag => scenario.tags.map(t => t.name).includes(tag));
+  }
 
-    return false;
+  _scenarioLacksTags(scenario, tags) {
+    return !tags.length || !this._scenarioHasAnyOfTheTags(scenario, tags);
   }
 };

--- a/src/args.js
+++ b/src/args.js
@@ -64,11 +64,13 @@ module.exports = require('yargs')
   .option('app', {
     alias: 'a',
     default: null,
-    describe: 'Executes the specified shell command before running tests. Use it to launch or deploy the application you are going to test.',
+    describe:
+      'Executes the specified shell command before running tests. Use it to launch or deploy the application you are going to test.'
   })
   .option('appInitDelay', {
     default: 0,
-    describe: 'Specifies the time (in milliseconds) allowed for an application launched using the --app option to initialize.',
+    describe:
+      'Specifies the time (in milliseconds) allowed for an application launched using the --app option to initialize.',
     type: 'number'
   })
   .option('tags', {


### PR DESCRIPTION
Hi! I needed the ability to be able to commit incomplete scenarios but mark them so that the CI-system would not run them. I simply added the not-operator '\~' that can specify tags that must not be present on scenarios if they are to run. The '\~@TAG'-style is older gherkin, while the newer style uses "not @TAG" instead, but I did not want to include a space lest it interferes with the CLI.

My first pull request btw :)