### PR TITLE
Allow using string in step definitions pattern

### DIFF
--- a/examples/google.js
+++ b/examples/google.js
@@ -9,12 +9,12 @@ Before('@googleHook', async () => {
   console.log('Running Google e2e test.');
 });
 
-Given(/^I am open Google's search page$/, async t => {
+Given('I am open Google\'s search page', async t => {
   await t.navigateTo('http://www.google.com');
 });
 
 When(/^I am typing my search request "(.+)" on Google$/, async (t, searchRequest) => {
-  const input = Selector('#lst-ib', t);
+  const input = Selector('[name="q"]', t);
 
   await t.typeText(input, searchRequest);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.116",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
-      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==",
+      "version": "4.14.120",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/@types/lodash/-/lodash-4.14.120.tgz",
+      "integrity": "sha1-zyZdBvbHpxDbCH7QdSOrjBokBHs=",
       "dev": true
     },
     "amdefine": {
@@ -81,8 +81,8 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -132,8 +132,8 @@
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assertion-error-formatter": {
@@ -160,14 +160,14 @@
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
     "atob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "version": "2.1.2",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "babel-code-frame": {
@@ -183,8 +183,8 @@
     },
     "babel-core": {
       "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -210,8 +210,8 @@
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "dev": true,
       "requires": {
         "babel-messages": "^6.23.0",
@@ -622,8 +622,8 @@
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
       "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
@@ -758,6 +758,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-for-of-as-array": {
+      "version": "1.1.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babel-plugin-transform-for-of-as-array/-/babel-plugin-transform-for-of-as-array-1.1.1.tgz",
+      "integrity": "sha1-8Y/Ly/orjK7RRFwxU4k9N0OaZTc=",
+      "dev": true
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
@@ -798,8 +804,8 @@
     },
     "babel-preset-env": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha1-3qefpOvriDzTXasH4mDBycBN93o=",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
@@ -885,8 +891,8 @@
       "dependencies": {
         "source-map-support": {
           "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
           "dev": true,
           "requires": {
             "source-map": "^0.5.6"
@@ -948,8 +954,8 @@
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
       "dev": true
     },
     "balanced-match": {
@@ -959,8 +965,8 @@
     },
     "base64-js": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
       "dev": true
     },
     "becke-ch--regex--s0-0-v1--base--pl--lib": {
@@ -970,9 +976,9 @@
       "dev": true
     },
     "bin-v8-flags-filter": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bin-v8-flags-filter/-/bin-v8-flags-filter-1.1.3.tgz",
-      "integrity": "sha512-8qoUG3/BSI9UCQaaBy7exflQFAy3Hfy5Qyyn9+7IlTVCe3tHZ3cozsRk7/2SuOzvFChuQuL3Jmc4ed5jGygHaQ==",
+      "version": "1.2.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/bin-v8-flags-filter/-/bin-v8-flags-filter-1.2.0.tgz",
+      "integrity": "sha1-Aj/E7iKZmysfbdG3JTYhNmhBU34=",
       "dev": true
     },
     "bluebird": {
@@ -1007,8 +1013,8 @@
     },
     "browserslist": {
       "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30000844",
@@ -1017,8 +1023,8 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "callsite": {
@@ -1029,8 +1035,8 @@
     },
     "callsite-record": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/callsite-record/-/callsite-record-4.1.3.tgz",
-      "integrity": "sha512-otAcPmu8TiHZ38cIL3NjQa1nGoSQRRe8WDDUgj5ZUwJWn1wzOYBwVSJbpVyzZ0sesQeKlYsPu9DG70fhh6AK9g==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/callsite-record/-/callsite-record-4.1.3.tgz",
+      "integrity": "sha1-MEHSoccq/4awCxUeR9JVZlIMQgc=",
       "dev": true,
       "requires": {
         "@types/error-stack-parser": "^1.3.18",
@@ -1045,17 +1051,17 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -1064,9 +1070,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1080,20 +1086,23 @@
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
-      "version": "1.0.30000874",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
-      "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w==",
+      "version": "1.0.30000934",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/caniuse-lite/-/caniuse-lite-1.0.30000934.tgz",
+      "integrity": "sha1-Ty10n1Hp4tTpsYL48SHSbsQgjo0=",
       "dev": true
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.2.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -1109,16 +1118,22 @@
         "supports-color": "^2.0.0"
       }
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "chrome-emulated-devices-list": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/chrome-emulated-devices-list/-/chrome-emulated-devices-list-0.1.1.tgz",
-      "integrity": "sha512-wQu6YKNTNGaUXovpkvXLnfeumVK47r2TKpOuCTwOKv/5SmRzfHual+E+oDIwS3KFWAcJPAhoNRAOLvXwzC6/pw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/chrome-emulated-devices-list/-/chrome-emulated-devices-list-0.1.1.tgz",
+      "integrity": "sha1-nuAwwhqm0GX75WLzzkHuJXWF/WA=",
       "dev": true
     },
     "chrome-remote-interface": {
       "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
-      "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
+      "integrity": "sha1-gn6F++88xWGp7yQE637uNVloxbw=",
       "dev": true,
       "requires": {
         "commander": "2.11.x",
@@ -1127,16 +1142,16 @@
       "dependencies": {
         "commander": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
           "dev": true
         }
       }
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "version": "1.6.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
       "dev": true
     },
     "cli-table": {
@@ -1200,19 +1215,25 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "coffeescript": {
+      "version": "2.3.2",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/coffeescript/-/coffeescript-2.3.2.tgz",
+      "integrity": "sha1-6FSnAg3+R7fPTdQSBC4y7x4mmBA=",
+      "dev": true
+    },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "version": "1.1.3",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -1239,10 +1260,13 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js": {
       "version": "2.5.5",
@@ -1285,8 +1309,8 @@
     },
     "css": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/css/-/css-2.2.3.tgz",
+      "integrity": "sha1-+GH0umHnm+3JYqpUjleA/ZXLxr4=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1376,8 +1400,8 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -1401,18 +1425,53 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
+        "type-detect": "^4.0.0"
+      }
+    },
+    "del": {
+      "version": "3.0.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "dev": true,
+      "requires": {
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
@@ -1443,15 +1502,21 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.55",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.55.tgz",
-      "integrity": "sha1-8VDhCyC3fZ1Br8yjEu/gw7Gn/c4=",
+      "version": "1.3.113",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+      "integrity": "sha1-scz2Gd9yla6he8aVHcaJYyYp5Kk=",
       "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.4.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/emittery/-/emittery-0.4.1.tgz",
+      "integrity": "sha1-q+nTKXOJukJKyH5T0ccBliznQz0=",
       "dev": true
     },
     "endpoint-utils": {
@@ -1609,6 +1674,12 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -1640,8 +1711,8 @@
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -1689,15 +1760,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
       "dev": true
     },
     "gulp-clone": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-clone/-/gulp-clone-2.0.1.tgz",
-      "integrity": "sha512-SLg/KsHBbinR/pCX3PF5l1YlR28hLp0X+bcpf77PtMJ6zvAQ5kRjtCPV5Wt1wHXsXWZN0eTUZ15R8ZYpi/CdCA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/gulp-clone/-/gulp-clone-2.0.1.tgz",
+      "integrity": "sha1-z07LKMpG0DL2lJJx6L95hueOb/k=",
       "dev": true,
       "requires": {
         "plugin-error": "^0.1.2",
@@ -1706,8 +1777,8 @@
     },
     "gulp-data": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/gulp-data/-/gulp-data-1.3.1.tgz",
-      "integrity": "sha512-fvpQJvgVyhkwRcFP3Y9QUS9sWvIFsAlJDinQjhLuknmHZz52jH0gHmTujYBFjr9aTlTHlrAayY5m1d0tA1HzGQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/gulp-data/-/gulp-data-1.3.1.tgz",
+      "integrity": "sha1-MwTV0SA9VU0zheQt547pIE9hyKI=",
       "dev": true,
       "requires": {
         "plugin-error": "^0.1.2",
@@ -1717,8 +1788,8 @@
     },
     "gulp-run-command": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gulp-run-command/-/gulp-run-command-0.0.9.tgz",
-      "integrity": "sha512-8/Gzh+zfe6CFLqaL+LxwqLPj5fk/N1eCHEr36K5p9Al40iuxpbVnq1aZRGXMj+4DlWBzjjAAxas3EkMNI/6Vcw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/gulp-run-command/-/gulp-run-command-0.0.9.tgz",
+      "integrity": "sha1-zz/hyn6tUKiD9LpABMqjTKY6Y8w=",
       "dev": true,
       "requires": {
         "babel-plugin-transform-runtime": "6.15.0",
@@ -1747,9 +1818,9 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -1775,8 +1846,8 @@
     },
     "highlight-es": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.3.tgz",
-      "integrity": "sha512-s/SIX6yp/5S1p8aC/NRDC1fwEb+myGIfp8/TzZz0rtAv8fzsdX7vGl3Q1TrXCsczFq8DI3CBFBCySPClfBSdbg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/highlight-es/-/highlight-es-1.0.3.tgz",
+      "integrity": "sha1-EqvDAKJ+aG9vGAEBNOOlxtL+aTA=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.0",
@@ -1786,17 +1857,17 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -1805,9 +1876,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1829,6 +1900,12 @@
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
       "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "3.1.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/import-lazy/-/import-lazy-3.1.0.tgz",
+      "integrity": "sha1-iRJ5ICyKIoD9vWZ029jaGh38Z8w=",
       "dev": true
     },
     "indent-string": {
@@ -1875,8 +1952,8 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
@@ -1893,12 +1970,12 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.5.0"
       }
     },
     "is-es2016-keyword": {
@@ -1943,6 +2020,30 @@
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-stream": {
@@ -2034,8 +2135,8 @@
     },
     "log-update-async-hook": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz",
-      "integrity": "sha512-HQwkKFTZeUOrDi1Duf2CSUa/pSpcaCHKLdx3D/Z16DsipzByOBffcg5y0JZA1q0n80dYgLXe2hFM9JGNgBsTDw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz",
+      "integrity": "sha1-brqJ2+Z/oS0LIKxH33lClHrx/NE=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^2.0.0",
@@ -2054,8 +2155,8 @@
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2073,6 +2174,23 @@
       "integrity": "sha1-UczQtPwMhDWH16VwnOTTt2Kb7cU=",
       "dev": true
     },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "map-reverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-reverse/-/map-reverse-1.0.1.tgz",
@@ -2081,8 +2199,8 @@
     },
     "match-url-wildcard": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-url-wildcard/-/match-url-wildcard-0.0.2.tgz",
-      "integrity": "sha512-XQWEV4NdsB6HymtjW5sJthh1oHr/IZZPp+lOhu+RPkWDD0iQYXVCe8ozGQmi5ZxWqXYteERjHhN80zxLV/TNWA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/match-url-wildcard/-/match-url-wildcard-0.0.2.tgz",
+      "integrity": "sha1-amWF4ktSsdraAzxbYW8T8/7euYg=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -2107,8 +2225,8 @@
     },
     "mime": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
       "dev": true
     },
     "mimic-fn": {
@@ -2140,15 +2258,15 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.24.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s=",
       "dev": true
     },
-    "moment-duration-format": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
-      "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k=",
+    "moment-duration-format-commonjs": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.0.tgz",
+      "integrity": "sha1-3F3mEubW/0H3dNA3cqE5o2NWO8M=",
       "dev": true
     },
     "ms": {
@@ -2158,9 +2276,9 @@
       "dev": true
     },
     "mustache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
-      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
+      "version": "2.3.2",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha1-ptTZw/kdEzWauImoEpVPkjCj0MU=",
       "dev": true
     },
     "mz": {
@@ -2175,9 +2293,9 @@
       }
     },
     "nanoid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.1.0.tgz",
-      "integrity": "sha512-iOCqgXieGrk8/wDt1n9rZS2KB1dYVssemY0NTWjfzVr+1t1gAmdTp1u2+YHppKro3Bk5S+Gs+xmYCfpuXauYXQ==",
+      "version": "1.3.4",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/nanoid/-/nanoid-1.3.4.tgz",
+      "integrity": "sha1-rYn2LJ0fT9aXENSpCVPSiT0tMfQ=",
       "dev": true
     },
     "next-tick": {
@@ -2197,8 +2315,8 @@
     },
     "node-version": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
-      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/node-version/-/node-version-1.2.0.tgz",
+      "integrity": "sha1-NP3j/6jhFJvTI5g0ed2mIOG1Bg0=",
       "dev": true
     },
     "npm-run-path": {
@@ -2286,6 +2404,12 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -2316,6 +2440,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -2325,6 +2455,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "pify": {
@@ -2363,8 +2499,8 @@
     },
     "pngjs": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.3.tgz",
-      "integrity": "sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/pngjs/-/pngjs-3.3.3.tgz",
+      "integrity": "sha1-hRc3A73j7ayJmHV7luWCHQlmohs=",
       "dev": true
     },
     "prettier": {
@@ -2375,14 +2511,14 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/private/-/private-0.1.8.tgz",
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "progress": {
@@ -2437,8 +2573,8 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -2452,8 +2588,8 @@
     },
     "regenerate": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
       "dev": true
     },
     "regenerator-runtime": {
@@ -2464,8 +2600,8 @@
     },
     "regenerator-transform": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -2523,9 +2659,9 @@
       }
     },
     "replicator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/replicator/-/replicator-1.0.2.tgz",
-      "integrity": "sha512-y2yeUd+NDfSk6SHELNJfMwglmjDYxw65VKgDYMEYGLdJVnqz/sER0mFJbHrawqKfQoVRJ5vN3pSouL9ZLUVd8w==",
+      "version": "1.0.3",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/replicator/-/replicator-1.0.3.tgz",
+      "integrity": "sha1-wLPqMedJAVuuXVInPyrjXVQbh+8=",
       "dev": true
     },
     "require-directory": {
@@ -2566,8 +2702,8 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true
     },
     "resolve-url": {
@@ -2576,10 +2712,35 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "sanitize-filename": {
@@ -2598,9 +2759,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.6.0",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
       "dev": true
     },
     "serialize-error": {
@@ -2646,8 +2807,8 @@
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
         "atob": "^2.1.1",
@@ -2658,9 +2819,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "version": "0.5.10",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha1-IhQIC8nVGDJRHuK6uW48L5NTEgw=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -2669,8 +2830,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -2785,8 +2946,8 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -2830,14 +2991,15 @@
       }
     },
     "testcafe": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-0.20.5.tgz",
-      "integrity": "sha512-clCWZmR6OzsCS2LxkHnk4xaSgH9Lyw7PRgwJ4XJv5k2mchuj1qHQuLHj/lRYkciQlZt78V5/wHV+C3To6od4mw==",
+      "version": "0.23.3",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/testcafe/-/testcafe-0.23.3.tgz",
+      "integrity": "sha1-j5xlEbQ6yZWT1TK7CK4GxV/3K1w=",
       "dev": true,
       "requires": {
         "async-exit-hook": "^1.1.2",
         "babel-core": "^6.22.1",
         "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-for-of-as-array": "^1.1.1",
         "babel-plugin-transform-runtime": "^6.22.0",
         "babel-preset-env": "^1.1.8",
         "babel-preset-flow": "^6.23.0",
@@ -2846,28 +3008,33 @@
         "bin-v8-flags-filter": "^1.1.2",
         "callsite": "^1.0.0",
         "callsite-record": "^4.0.0",
-        "chai": "^3.0.0",
+        "chai": "^4.1.2",
         "chalk": "^1.1.0",
         "chrome-emulated-devices-list": "^0.1.0",
         "chrome-remote-interface": "^0.25.3",
+        "coffeescript": "^2.3.1",
         "commander": "^2.8.1",
         "debug": "^2.2.0",
         "dedent": "^0.4.0",
+        "del": "^3.0.0",
         "elegant-spinner": "^1.0.1",
+        "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
         "globby": "^3.0.1",
         "graceful-fs": "^4.1.11",
         "gulp-data": "^1.3.1",
+        "import-lazy": "^3.1.0",
         "indent-string": "^1.2.2",
         "is-ci": "^1.0.10",
         "is-glob": "^2.0.1",
+        "is-stream": "^1.1.0",
         "lodash": "^4.17.10",
         "log-update-async-hook": "^2.0.2",
+        "make-dir": "^1.3.0",
         "map-reverse": "^1.0.1",
-        "mkdirp": "^0.5.1",
         "moment": "^2.10.3",
-        "moment-duration-format": "^2.2.2",
+        "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
         "nanoid": "^1.0.1",
         "node-version": "^1.0.0",
@@ -2880,15 +3047,15 @@
         "ps-node": "^0.1.6",
         "qrcode-terminal": "^0.10.0",
         "read-file-relative": "^1.2.0",
-        "replicator": "^1.0.0",
+        "replicator": "^1.0.3",
         "resolve-cwd": "^1.0.0",
         "resolve-from": "^4.0.0",
         "sanitize-filename": "^1.6.0",
         "source-map-support": "^0.5.5",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "1.6.4",
-        "testcafe-hammerhead": "14.2.2",
-        "testcafe-legacy-api": "3.1.7",
+        "testcafe-browser-tools": "1.6.5",
+        "testcafe-hammerhead": "14.4.7",
+        "testcafe-legacy-api": "3.1.9",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -2910,9 +3077,9 @@
       }
     },
     "testcafe-browser-tools": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.6.4.tgz",
-      "integrity": "sha512-I0PsEVT39C7MpjIDjJWKc7zPEl5GFAGgl/4eO8NISaJbITL0czeX9ITomMV6m3IZtk6WUWlIkOkl9R04GVa4fw==",
+      "version": "1.6.5",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/testcafe-browser-tools/-/testcafe-browser-tools-1.6.5.tgz",
+      "integrity": "sha1-i0Hr+ETczIEOgufxnMnSV/jGrYY=",
       "dev": true,
       "requires": {
         "array-find": "^1.0.0",
@@ -2946,9 +3113,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-14.2.2.tgz",
-      "integrity": "sha512-n9vM5NeVbpv30L/73vKJe/O0AoBJWMfB9UVNAZOBuc7uleQ9jnHSaTXDOJjNO+5STVe3oPBqvQ7FDTX43m/c3A==",
+      "version": "14.4.7",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/testcafe-hammerhead/-/testcafe-hammerhead-14.4.7.tgz",
+      "integrity": "sha1-myeUhkGZtAo0RYWcH5hxkdO5ZQ8=",
       "dev": true,
       "requires": {
         "bowser": "1.6.0",
@@ -2973,14 +3140,13 @@
         "semver": "5.5.0",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "webauth": "^1.1.0",
-        "yakaa": "1.0.1"
+        "webauth": "^1.1.0"
       },
       "dependencies": {
         "nanoid": {
           "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-0.2.2.tgz",
-          "integrity": "sha512-GHoRrvNEKiwdkwQ/enKL8AhQkkrBC/2KxMZkDvQzp8OtkpX8ZAmoYJWFVl7l8F2+HcEJUfdg21Ab2wXXfrvACQ==",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/nanoid/-/nanoid-0.2.2.tgz",
+          "integrity": "sha1-4uvGrT214EVP2BJNMMo5sGVV/lY=",
           "dev": true
         },
         "pinkie": {
@@ -2988,13 +3154,19 @@
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
           "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
           "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+          "dev": true
         }
       }
     },
     "testcafe-legacy-api": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-3.1.7.tgz",
-      "integrity": "sha512-NfFUyq1rtgPDwzl7YbXV2kWgpC5qYsU7abVl4Zsk8XlpWx0QkUlWRdHSPomFdHDDOdGjTqotqPwjbSFiI9LUFA==",
+      "version": "3.1.9",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/testcafe-legacy-api/-/testcafe-legacy-api-3.1.9.tgz",
+      "integrity": "sha1-nxpzCurlbHJITztOZc1YverGvQ4=",
       "dev": true,
       "requires": {
         "async": "0.2.6",
@@ -3089,19 +3261,19 @@
       }
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
+        "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
     },
     "time-limit-promise": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/time-limit-promise/-/time-limit-promise-1.0.4.tgz",
-      "integrity": "sha512-FLHDDsIDducw7MBcRWlFtW2Tm50DoKOSFf0Nzx17qwXj8REXCte0eUkHrJl9QU3Bl9arG3XNYX0PcHpZ9xyuLw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/time-limit-promise/-/time-limit-promise-1.0.4.tgz",
+      "integrity": "sha1-M+koISJzxw1SFTworSp+Mxm5dfk=",
       "dev": true
     },
     "timeout-as-promise": {
@@ -3145,9 +3317,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+      "version": "1.2.1",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha1-U5jzdOLykrncx7LnHjClw7tsdDo=",
       "dev": true
     },
     "trim-right": {
@@ -3175,21 +3347,21 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "typescript": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha1-HL9h0F1rliaSROtqO85L2RTg8Aw=",
       "dev": true
     },
     "ultron": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
       "dev": true
     },
     "upper-case": {
@@ -3206,8 +3378,8 @@
     },
     "useragent": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha1-IX+UOtVAyyEoZYqyP8lg9qiMmXI=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.x",
@@ -3215,9 +3387,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -3324,8 +3496,8 @@
     },
     "ws": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "resolved": "https://repo.dev.kiwigrid.com/artifactory/api/npm/central-npm/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",
@@ -3343,12 +3515,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yakaa": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz",
-      "integrity": "sha1-PsqucvPQidpYCJQDEmIEzsdy5go=",
-      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "gherkin-testcafe",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Lukas Kullmann <lukas.kullmann@kiwigrid.com>",
   "contributors": [
     "Wilhelm Behncke <behncke@sitegeist.de>",
     "Jarmo Koivisto",
     "Jakob Ström",
-    "Jussi Mullo"
+    "Jussi Mullo",
+    "Mert Susur"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   },
   "peerDependencies": {
     "cucumber": "^4.2.1",
-    "testcafe": "^0.20.0"
+    "testcafe": "^0.23.3"
   },
   "devDependencies": {
     "cucumber": "^4.2.1",
     "prettier": "^1.14.2",
-    "testcafe": "^0.20.0"
+    "testcafe": "^0.23.3"
   }
 }

--- a/src/TestcafeGherkinBootstrapper.js
+++ b/src/TestcafeGherkinBootstrapper.js
@@ -100,10 +100,9 @@ module.exports = class TestcafeGherkinBootstrapper extends TestcafeBootstrapper 
 
   _resolveAndRunStepDefinition(testController, step) {
     for (const stepDefinition of this.stepDefinitions) {
-      const match = stepDefinition.pattern.exec(step.text);
-
-      if (match) {
-        return this._runStep(stepDefinition.code, testController, match.slice(1));
+      const [isMatched, parameters] = this._shouldRunStep(stepDefinition, step);
+      if (isMatched) {
+        return this._runStep(stepDefinition.code, testController, parameters);
       }
     }
 
@@ -144,6 +143,15 @@ module.exports = class TestcafeGherkinBootstrapper extends TestcafeBootstrapper 
       this._scenarioHasAnyOfTheTags(scenario, this._getIncludingTags(this.tags)) &&
       this._scenarioLacksTags(scenario, this._getExcludingTags(this.tags))
     );
+  }
+
+  _shouldRunStep(stepDefinition, step) {
+    if (typeof stepDefinition.pattern === 'string') {
+      return [stepDefinition.pattern === step.text, []];
+    } else if (typeof stepDefinition.pattern.exec === 'function') {
+      const match = stepDefinition.pattern.exec(step.text);
+      return [Boolean(match), match ? match.slice(1) : []];
+    }
   }
 
   _getIncludingTags(tags) {

--- a/src/TestcafeGherkinBootstrapper.js
+++ b/src/TestcafeGherkinBootstrapper.js
@@ -148,10 +148,11 @@ module.exports = class TestcafeGherkinBootstrapper extends TestcafeBootstrapper 
   _shouldRunStep(stepDefinition, step) {
     if (typeof stepDefinition.pattern === 'string') {
       return [stepDefinition.pattern === step.text, []];
-    } else if (typeof stepDefinition.pattern.exec === 'function') {
+    } else if (stepDefinition.pattern instanceof RegExp) {
       const match = stepDefinition.pattern.exec(step.text);
       return [Boolean(match), match ? match.slice(1) : []];
     }
+    throw new Error(`Step implementation is not valid for: ${step.text}`);
   }
 
   _getIncludingTags(tags) {

--- a/src/TestcafeGherkinBootstrapper.js
+++ b/src/TestcafeGherkinBootstrapper.js
@@ -152,7 +152,10 @@ module.exports = class TestcafeGherkinBootstrapper extends TestcafeBootstrapper 
       const match = stepDefinition.pattern.exec(step.text);
       return [Boolean(match), match ? match.slice(1) : []];
     }
-    throw new Error(`Step implementation is not valid for: ${step.text}`);
+
+    const stepType = step.text instanceof Object ? step.text.constructor.name : typeof step.text;
+
+    throw new Error(`Step implementation invalid. Has to be a string or RegExp. Received ${stepType}`);
   }
 
   _getIncludingTags(tags) {


### PR DESCRIPTION
This proposal for allowing string and regex in the step definition patterns. I find it very unusual and enforcing to only allow regex in the step definitions, therefore made some changes for it to allow strings as well. So feel free to close this PR if that was the required behaviour! 🍻 

Before the change this line wouldn't work.

```js
Given('I am open Google\'s search page', async t => { 
// ...
});
```

Also the example test was failing because apparently google changed their selector, I made some small changes so it should be passing now.