### PR TITLE
Adds support for using http proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once official support is established, this package will be abandoned.
 Install `gherkin-testcafe` and `cucumber`<sup>1</sup> via npm or yarn:
 
     npm i gherkin-testcafe cucumber
-    
+
 or
 
     yarn add gherkin-testcafe cucumber
@@ -27,9 +27,9 @@ You will need it to define steps (see [Writing step definitions](#writing-step-d
 Use the `gherkin-testcafe` package to run test via CLI:
 
     gherkin-testcafe --steps tests/**/*.js --specs tests/**/*.feature --browsers firefox
-    
+
 You can use shorthands:
-    
+
     gherkin-testcafe -d tests/**/*.js -s tests/**/*.feature -b firefox
 
 Out of [TestCafé's CLI options](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#options) a limited amount are supported for this package.
@@ -37,7 +37,7 @@ Out of [TestCafé's CLI options](https://devexpress.github.io/testcafe/documenta
 The following options are supported:
 
 | Option | Shorthand | Required |Description | Default
-| --- | ---| --- | --- | --- | 
+| --- | ---| --- | --- | --- |
 | specs | s | **Required** | A space separated list of feature files to run.We use [glob](https://github.com/isaacs/node-glob) to match paths. | N.A. |
 | steps | d | **Required** | A space separated list of file paths to load the step definitions from. We use [glob](https://github.com/isaacs/node-glob) to match paths. | N.A. |
 | browsers | b | Optional | A space separated list of browsers to run the tests in. | chrome:headless |
@@ -57,7 +57,7 @@ The following options are supported:
 | app | a | Optional | Executes the specified shell command before running tests. Use it to launch or deploy the application you are going to test. | null |
 | appInitDelay | N.A. | Optional | Specifies the time (in milliseconds) allowed for an application launched using the --app option to initialize. | 0 |
 | tags | t | Optional | Run only tests having the specified tags | [] |
-| proxy | x | Optional | Specifies the proxy server used in your local network to access the Internet | null |
+| proxy | N.A.| Optional | Specifies the proxy server used in your local network to access the Internet | null |
 
 ## Programming interface
 
@@ -75,7 +75,7 @@ module.exports = async () => {
     const testcafe = await createTestCafe();
     const runner = await testcafe.createRunner();
     const remoteConnection = await testcafe.createBrowserConnection();
-    
+
     return runner
 -       .src('test.js')
 +       .steps('steps/**/*.js')
@@ -93,9 +93,9 @@ Just like `src`, you can add multiple paths to search for `specs` and `steps`:
 runner
     .step('location-1/*.js')
     .step('location-2/*.js');
-    
+
 // or
-    
+
 runner.step(['location-1/*.js', 'location-2/*.js'])
 ```
 
@@ -191,7 +191,7 @@ Before('@tag1', async (t) => {
 });
 ```
 
-In the future, untagged hooks will be supported. 
+In the future, untagged hooks will be supported.
 
 #### `BeforeAll` and `AfterAll`
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following options are supported:
 | app | a | Optional | Executes the specified shell command before running tests. Use it to launch or deploy the application you are going to test. | null |
 | appInitDelay | N.A. | Optional | Specifies the time (in milliseconds) allowed for an application launched using the --app option to initialize. | 0 |
 | tags | t | Optional | Run only tests having the specified tags | [] |
+| proxy | x | Optional | Specifies the proxy server used in your local network to access the Internet | null |
 
 ## Programming interface
 

--- a/src/args.js
+++ b/src/args.js
@@ -108,4 +108,10 @@ module.exports = require('yargs')
     default: [],
     describe: 'Run only tests having the specified tags',
     type: 'array'
+  })
+  .option('proxy', {
+    alias: 'x',
+    default: null,
+    describe: 'Specifies the proxy server used in your local network to access the Internet.',
+    type: 'string'
   });

--- a/src/args.js
+++ b/src/args.js
@@ -110,7 +110,6 @@ module.exports = require('yargs')
     type: 'array'
   })
   .option('proxy', {
-    alias: 'x',
     default: null,
     describe: 'Specifies the proxy server used in your local network to access the Internet.',
     type: 'string'

--- a/src/runner.js
+++ b/src/runner.js
@@ -20,7 +20,8 @@ module.exports = async ({
   concurrency,
   app,
   appInitDelay,
-  tags
+  tags,
+  proxy
 }) => {
   const testcafe = await createTestCafe(hostname, ...ports.slice(0, 2));
   const runner = testcafe.createRunner();
@@ -31,6 +32,7 @@ module.exports = async ({
       .specs(specs)
       .steps(steps)
       .concurrency(concurrency)
+      .useProxy(proxy)
       .startApp(app, appInitDelay)
       .tags(tags)
       .run({


### PR DESCRIPTION
Adding the ability to use proxy while connecting to the websites. This is using the `useProxy` function on runner described in the [test-cafe documentation](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#useproxy).