### PR TITLE
Add support for state management of steps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { TableDefinition } from 'cucumber';
+import { TableDefinition, World } from 'cucumber';
 import testcafe, { t } from 'testcafe';
 
 export * from 'testcafe';
@@ -16,6 +16,7 @@ declare module 'cucumber' {
   export function BeforeAll(code: GlobalHookFunction): void;
 
   export type StepFunction = (
+    this: World,
     testController: typeof t,
     parameters: any[],
     dataTable: TableDefinition | null


### PR DESCRIPTION
This PR supports for sharing state between step definitions which is cucumber's feature.
https://cucumber.io/docs/cucumber/step-definitions/#state-management

Same as cucumber, state can be shared via `this` of a step function.