### PR TITLE
Match TestCafe fixture context indexer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export default testcafe;
 
 declare module 'cucumber' {
   export type HookFunction = (testController: typeof t) => Promise<void>;
-  export type GlobalHookFunction = (fixtureContext: { [key: string]: string }) => Promise<void>;
+  export type GlobalHookFunction = (fixtureContext: { [key: string]: any }) => Promise<void>;
 
   export function After(code: HookFunction): void;
   export function After(options: string, code: HookFunction): void;


### PR DESCRIPTION
Before & After have this signature: `before(fn: (ctx: {[key: string]: any}) => Promise<any>): this;`

https://github.com/DevExpress/testcafe/blob/master/ts-defs/index.d.ts#L1892