### PR TITLE
improve tag handling (closes kiwigrid#52)

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -12,6 +12,12 @@ module.exports = class GherkinTestcafeRunner extends TestcafeRunner {
   tags(...tags) {
     if (this.apiMethodWasCalled.tags) throw new GeneralError(RUNTIME_ERRORS.multipleAPIMethodCallForbidden, 'tags');
 
+    // remove tags from previous runs (if starting multiple runs in a row in the same process)
+    const tagsIndex = process.argv.findIndex(val => val === '--tags');
+    if (tagsIndex !== -1) {
+      process.argv.splice(tagsIndex, 2);
+    }
+
     tags = this._prepareArrayParameter(tags);
 
     process.argv.push('--tags', tags.join(','));


### PR DESCRIPTION
Allows users to use an AND operator between tags.

Example:
```
@tag1 @tag2
Scenario1: ...

@tag1
Scenario2: ...

@tag2
Scenario3: ...
```

Using runner.tags('@tag1','@tag2'), all 3 scenarios would run.
Using runner.tags('@tag1 and @tag2'), only Scenario1 would run.
Will also work in CLI
```
--tags "@tag1 and @tag2"
```